### PR TITLE
Stop eventListener during win display

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,8 +6,10 @@ statusTitle = document.querySelector('.game-status');
 
 
 board.addEventListener('click', function(event) {
-    var currentID = event.target.id;
-    manageBoardClick(currentID);
+    if (!actionStop){
+        var currentID = event.target.id;
+        manageBoardClick(currentID);
+    }
 });
 
 
@@ -47,6 +49,7 @@ var player2 = {
 
 availableSquares = ['a1', 'a2', 'a3', 'b1', 'b2', 'b3', 'c1', 'c2', 'c3'];
 whosTurn = 'player1';
+var actionStop = false;
 
 // maybe one displayAll() function broken up into the different displays?
 function manageBoardClick(iD) {
@@ -148,8 +151,10 @@ function processEndGame(winner) {
         manageGameEnd('draw');  
     }
     resetStored();
+    actionStop = true;
     setTimeout(displayIcons, 3000);
     setTimeout(toggleTurn, 3000);
+    setTimeout(function(){actionStop = false}, 3000);
 }
 
 function updateWins() {


### PR DESCRIPTION
### Summary
- set up a variable set to false.
- when variable is true, eventListener on grid will not do anything.
- set variable to true only when the delayed functions are waiting to fire.

### Notes/ToDo
- maybe there is a better way, but I like this fix!