### PR TITLE
Refactor/simplify for cpu mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,12 @@
 <head>
+    <title>Tic Tactical Toto</title>
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
     <aside>
         <div class="p1-icon">
             <h3>X</h3>
-            <!-- <img class='player-icon' src="./assets/toto.png" alt="toto"> -->
+            <!-- toto head will go here when in oz mode -->
         </div>
         <h3 class="wins" id="p1Wins">0 wins<h3>
     </aside>
@@ -29,7 +30,7 @@
         <div class="p2-details">
             <div class="p2-icon">
                 <h3>O</h3>
-                <!-- <img class='player-icon' src="./assets/wicked-witch.png" alt="wicked-witch"> -->
+                <!-- witch head will go here when in oz mode -->
             </div>
             <h3 class="wins" id="p2Wins">0 wins<h3>
         </div>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
             <h3 class="wins" id="p2Wins">0 wins<h3>
         </div>
         <div class="toggle-region">
-            <p>enter tic-tac-toto -></p>
+            <p>tic-tactical-toto -></p>
             <img class='toggle-button' src="./assets/ruby-slippers.png" alt="wicked-witch">
         </div>
     </aside>

--- a/main.js
+++ b/main.js
@@ -116,7 +116,6 @@ function resetWins() {
     player2.wins = 0;
 }
 
-// maybe one displayAll() function broken up into the different displays?
 function manageBoardClick(iD) {
     if (availableSquares.includes(iD)) {
         storeSquare(iD);
@@ -131,7 +130,7 @@ function manageBoardClick(iD) {
                 setTimeout(displayTurn, 4000);
                 setTimeout(displayIcons, 3000)
                 if (whosTurn === 'player1') {
-                    setTimeout(generateTurn, 4000);
+                    setTimeout(generateTurn, 4750);
                 }
             } else {
                 actionStop = true;
@@ -146,7 +145,9 @@ function manageBoardClick(iD) {
             displayTurn();
             console.log('whosTurn before if', whosTurn)
             if (cPUMode && whosTurn === 'player2'){
+                actionStop = true;
                 setTimeout(generateTurn, 750);
+                setTimeout(function() {actionStop = false}, 750);
             }
         }
     }
@@ -185,7 +186,6 @@ function updateAvailable(iD) {
     }
 }
 
-//check for draw a different function?? Is toggleTurn weird here?
 function checkForWin() {
     var player = window[whosTurn];
     var result = {
@@ -233,7 +233,6 @@ function toggleTurn() {
     }
 }
 
-// i = avalableSquares.length as a way to bail out instead of action stop? Also availableSquares.length will change during this, which is not good.
 function generateTurn() {
     var conditionMet = false;
     var bestChoice;
@@ -409,7 +408,6 @@ function displayTurn() {
     }
 }
 
-// let's make better names for process and manage end game
 function processEndGame(winner) {
     if (winner != 'draw'){
         updateWins();

--- a/main.js
+++ b/main.js
@@ -102,7 +102,7 @@ function toggleTheme() {
         mainField.classList.remove('main-oz');
         board.classList.remove('board-oz');
         toggleButton.src = "./assets/ruby-slippers.png";
-        toggleText.innerText = 'enter tic-tac-toto ->'
+        toggleText.innerText = 'tic-tactical-toto ->'
         player1.token = 'X';
         player2. token = 'O';
         for (var i = 0; i < cells.length; i++) {
@@ -123,7 +123,6 @@ function manageBoardClick(iD) {
         updateAvailable(iD);
         displayIcons();
         var winCheck = checkForWin();
-        console.log('winCheck', winCheck)
         if (winCheck.gameOver) {
             if (cPUMode) {
                 actionStop = true;
@@ -143,10 +142,12 @@ function manageBoardClick(iD) {
             }
             processEndGame(winCheck.playerName);
         } else {
-            console.log ('made it here and whosTurn is', whosTurn)
             toggleTurn();
-            console.log ('made it here and whosTurn is', whosTurn)
             displayTurn();
+            console.log('whosTurn before if', whosTurn)
+            if (cPUMode && whosTurn === 'player2'){
+                setTimeout(generateTurn, 750);
+            }
         }
     }
 }


### PR DESCRIPTION
### Summary
- streamlined cPUMode conditions in manageBoardClick.
- cleaner use of actionStop such that event listener is paused only when presentations occur.

### Notes/ToDo
- getting close!
- could take a look at displayAll as a catch-all for displaying icons, wins, etc.